### PR TITLE
Add X-Userinfo header on introspection success as well

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -4,8 +4,6 @@ local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
-local cjson = require("cjson")
-
 OidcHandler.PRIORITY = 1000
 
 
@@ -40,8 +38,6 @@ function handle(oidcConfig)
     response = make_oidc(oidcConfig)
     if response and response.user then
       utils.injectUser(response.user)
-      local userinfo = cjson.encode(response.user)
-      ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
     end
   end
 end

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -1,3 +1,5 @@
+local cjson = require("cjson")
+
 local M = {}
 
 local function parseFilters(csvFilters)
@@ -69,6 +71,8 @@ function M.injectUser(user)
   tmp_user.id = user.sub
   tmp_user.username = user.preferred_username
   ngx.ctx.authenticated_credential = tmp_user
+  local userinfo = cjson.encode(user)
+  ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
 end
 
 function M.has_bearer_access_token()

--- a/test/unit/test_introspect.lua
+++ b/test/unit/test_introspect.lua
@@ -18,16 +18,32 @@ function TestIntrospect:test_access_token_exists()
   function dict:get(key) return key end
   _G.ngx.shared = {introspection = dict }
 
+  ngx.encode_base64 = function(x)
+    return "eyJzdWIiOiJzdWIifQ=="
+  end
+
+  local headers = {}
+  ngx.req.set_header = function(h, v)
+    headers[h] = v
+  end
+
   self.handler:access({introspection_endpoint = "x"})
   lu.assertTrue(self:log_contains("introspect succeeded"))
+  lu.assertEquals(headers['X-Userinfo'], "eyJzdWIiOiJzdWIifQ==")
 end
 
 function TestIntrospect:test_no_authorization_header()
   package.loaded["resty.openidc"].authenticate = function(...) return {}, nil end
   ngx.req.get_headers = function() return {} end
 
+  local headers = {}
+  ngx.req.set_header = function(h, v)
+    headers[h] = v
+  end
+
   self.handler:access({introspection_endpoint = "x"})
   lu.assertFalse(self:log_contains(self.mocked_ngx.ERR))
+  lu.assertEquals(headers['X-Userinfo'], nil)
 end
 
 


### PR DESCRIPTION
- moved `X-Userinfo` setting into `inject_user` method
- improved tests around this functionality