### PR TITLE
As well as setting X-Userinfo, set X-Credential-* headers

### DIFF
--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -73,6 +73,21 @@ function M.injectUser(user)
   ngx.ctx.authenticated_credential = tmp_user
   local userinfo = cjson.encode(user)
   ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
+
+  -- also set Kong defined X-Credential headers
+  -- for compaibility with their oauth2-introspection plugin
+  -- https://docs.konghq.com/enterprise/0.33-x/plugins/oauth2-introspection/
+  ngx.req.set_header("X-Credential-Scope", user.scope)
+  ngx.req.set_header("X-Credential-Client-ID", user.client_id)
+  ngx.req.set_header("X-Credential-Username", user.username)
+  ngx.req.set_header("X-Credential-Token-Type", user.token_type)
+  ngx.req.set_header("X-Credential-Exp", user.exp)
+  ngx.req.set_header("X-Credential-Iat", user.iat)
+  ngx.req.set_header("X-Credential-Nbf", user.nbf)
+  ngx.req.set_header("X-Credential-Sub", user.sub)
+  ngx.req.set_header("X-Credential-Aud", user.aud)
+  ngx.req.set_header("X-Credential-Iss", user.iss)
+  ngx.req.set_header("X-Credential-Jti", user.jti)
 end
 
 function M.has_bearer_access_token()


### PR DESCRIPTION
The [official Kong oauth2-introspection plugin](https://docs.konghq.com/enterprise/0.33-x/plugins/oauth2-introspection/) sets `X-Credential-*` headers when passing a request to the upstream service, by parsing the expected JWT fields from [RFC 7662](https://tools.ietf.org/html/rfc7662#page-6)

This PR sets these headers, to ensure interoperability between the community and official plugins.